### PR TITLE
Small build fix

### DIFF
--- a/5.0.0/ARO.Core/pom.xml
+++ b/5.0.0/ARO.Core/pom.xml
@@ -29,6 +29,13 @@
 		<maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>				
 	</properties>
 
+	<repositories>
+		<repository>
+			<id>com.springsource.repository.bundles.external</id>
+			<name>SpringSource Enterprise Bundle Repository - External Bundle Releases</name>
+			<url>http://repository.springsource.com/maven/bundles/external</url>
+		</repository>
+	</repositories>
 
 	<pluginRepositories>
 		<pluginRepository>
@@ -87,8 +94,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-				<!-- Note: You're going to need to download the jars and install them in your local maven repository, or 
-		local repository proxy server (Nexus/Artifactory).  -->		
 			<groupId>javax.media.jai</groupId>
 			<artifactId>com.springsource.javax.media.jai.core</artifactId>
 			<version>1.1.3</version>

--- a/5.0.0/ARO.Core/src/main/resources/analytics.properties
+++ b/5.0.0/ARO.Core/src/main/resources/analytics.properties
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ga.trackid=
 # Google Analytics Messages
 
 ga.request.event.category.analyzer=Analyzer


### PR DESCRIPTION
- slightly change 5.0.0/ARO.Core/pom.xml in order to automatically download com.springsource.javax.media.jai.core. 
- adds an empty ga.trackid property to be able to launch the GUI (that's for sure a quick fix but otherwise the compiled GUI app doesn't even show up)